### PR TITLE
Create life-cycle-of-token

### DIFF
--- a/life-cycle-of-token
+++ b/life-cycle-of-token
@@ -1,0 +1,2 @@
+The life cycle of the PEX token is perpetual unless and until purchased by Prime-Ex Perpetual via re-acquisition on the open markets with the intent to burn the token.  
+Except in this specific case the PEX token shall be valid, marketable, and negotiable in perpetuity.


### PR DESCRIPTION
The life cycle of the PEX token is perpetual unless and until purchased by Prime-Ex Perpetual via re-acquisition on the open markets with the intent to burn the token.  Except in this specific case the PEX token shall be valid, marketable, and negotiable in perpetuity.